### PR TITLE
feat: add academic request list screen and status badge widget

### DIFF
--- a/mobile/lib/core/constants/api_constants.dart
+++ b/mobile/lib/core/constants/api_constants.dart
@@ -51,4 +51,9 @@ class ApiConstants {
   // Chat Endpoints
   static const String chatGroups = '/api/v1/chat-groups';
   static const String chatMessages = '/api/v1/chat-messages';
+
+  // Academic Request Endpoints (Student)
+  static const String academicRequests = '/api/v1/academic-requests';
+  static const String academicRequestTypes = '/api/v1/academic-requests/types';
+  static const String academicRequestMyRequests = '/api/v1/academic-requests/my-requests';
 }

--- a/mobile/lib/core/constants/app_routes.dart
+++ b/mobile/lib/core/constants/app_routes.dart
@@ -14,4 +14,8 @@ class AppRoutes {
   static const String lecturerRequests = '/lecturer/requests';
   static const String lecturerRequestDetail = '/lecturer/requests/:id';
   static const String lecturerCreateRequest = '/lecturer/requests/create';
+
+  // Student Academic Request Routes
+  static const String studentAcademicRequests = '/student/academic-requests';
+  static const String studentAcademicRequestCreate = '/student/academic-requests/create';
 }

--- a/mobile/lib/core/services/api_service.dart
+++ b/mobile/lib/core/services/api_service.dart
@@ -110,6 +110,19 @@ class ApiService {
     }
   }
 
+  /// POST Multipart Request (for file uploads)
+  Future<Response> postMultipart(String path, {required FormData formData}) async {
+    try {
+      return await _dio.post(
+        path,
+        data: formData,
+        options: Options(contentType: 'multipart/form-data'),
+      );
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   /// DELETE Request
   Future<Response> delete(String path) async {
     try {

--- a/mobile/lib/features/academic_request/bindings/academic_request_bindings.dart
+++ b/mobile/lib/features/academic_request/bindings/academic_request_bindings.dart
@@ -1,0 +1,10 @@
+import 'package:get/get.dart';
+import '../controllers/academic_request_controller.dart';
+
+/// Binding for Academic Request feature
+class AcademicRequestBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<AcademicRequestController>(() => AcademicRequestController());
+  }
+}

--- a/mobile/lib/features/academic_request/controllers/academic_request_controller.dart
+++ b/mobile/lib/features/academic_request/controllers/academic_request_controller.dart
@@ -1,0 +1,502 @@
+import 'dart:io';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../core/constants/app_routes.dart';
+import '../../auth/controllers/auth_controller.dart';
+import '../../auth/models/user_model.dart';
+import '../models/academic_request_model.dart';
+import '../services/academic_request_service.dart';
+
+/// GetX Controller for Academic Request feature (Student side)
+class AcademicRequestController extends GetxController {
+  final AcademicRequestService _service = AcademicRequestService();
+
+  /// Get current student's ID (as String) from AuthController
+  String? get _currentStudentId {
+    try {
+      return Get.find<AuthController>().currentUser.value?.id;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // ─── List State ───────────────────────────────────────────────────────────
+  final RxList<AcademicRequest> requests = <AcademicRequest>[].obs;
+  final RxBool isLoading = false.obs;
+  final RxString statusFilter = ''.obs;
+  final RxString typeFilter = ''.obs;
+  final RxInt currentPage = 0.obs;
+  final RxInt totalPages = 0.obs;
+  final RxInt totalElements = 0.obs;
+  static const int pageSize = 10;
+
+  // ─── Request Types ─────────────────────────────────────────────────────────
+  final RxList<AcademicRequestType> requestTypes = <AcademicRequestType>[].obs;
+
+  // ─── Student Profile ───────────────────────────────────────────────────────
+  final Rxn<User> studentProfile = Rxn<User>();
+
+  // ─── Create Form State ─────────────────────────────────────────────────────
+  final Rxn<AcademicRequestType> selectedType = Rxn<AcademicRequestType>();
+  final RxBool isSubmitting = false.obs;
+
+  // Form fields
+  final RxString formRequestType = ''.obs;
+  final RxString formReason = ''.obs;
+  final RxString formNote = ''.obs;
+  final RxString formRequestTitle = ''.obs;
+
+  // Dropdown selections (IDs / values)
+  final Rxn<int> formSemesterId = Rxn<int>();
+  final Rxn<int> formCourseId = Rxn<int>();
+  final RxString formClassSectionId = ''.obs;
+  final RxString formToClassName = ''.obs;
+  final RxString formToMajor = ''.obs;
+  final RxString formToSpecialization = ''.obs;
+  final RxString formToSubSpecialization = ''.obs;
+
+  // ─── Supporting Data ───────────────────────────────────────────────────────
+  final RxList<SemesterOption> semesters = <SemesterOption>[].obs;
+  final RxList<CourseOption> myCourses = <CourseOption>[].obs;
+  // All curriculum courses (for RETAKE_COURSE, OVERLOAD_STUDY)
+  final RxList<CourseOption> allCurriculumCourses = <CourseOption>[].obs;
+  final RxList<ClassSectionOption> myClassSections = <ClassSectionOption>[].obs;
+  // All class sections (no semester filter) — needed for GRADE_APPEAL
+  final RxList<ClassSectionOption> allClassSections = <ClassSectionOption>[].obs;
+  final RxList<ClassSectionTransferTarget> transferTargets = <ClassSectionTransferTarget>[].obs;
+  final RxList<MajorOption> majors = <MajorOption>[].obs;
+  final RxList<SpecializationOption> specializations = <SpecializationOption>[].obs;
+  final RxList<SubSpecializationOption> subSpecializations = <SubSpecializationOption>[].obs;
+  final Rxn<GradeAppealInfo> gradeAppealInfo = Rxn<GradeAppealInfo>();
+  final RxBool loadingTargets = false.obs;
+  final RxBool loadingCourses = false.obs;
+  final RxBool loadingGradeAppealInfo = false.obs;
+
+  // ─── File Attachment ───────────────────────────────────────────────────────
+  final Rxn<File> selectedFile = Rxn<File>();
+  final RxString selectedFileName = ''.obs;
+
+  // ─── Lifecycle ─────────────────────────────────────────────────────────────
+  @override
+  void onInit() {
+    super.onInit();
+    fetchRequests();
+    fetchRequestTypes();
+    fetchSupportingData();
+  }
+
+  // ─── List Methods ──────────────────────────────────────────────────────────
+
+  Future<void> fetchRequests({bool reset = false}) async {
+    if (reset) {
+      currentPage.value = 0;
+      requests.clear();
+    }
+    try {
+      isLoading.value = true;
+      final result = await _service.getMyRequests(
+        page: currentPage.value,
+        size: pageSize,
+        status: statusFilter.value.isEmpty ? null : statusFilter.value,
+        requestType: typeFilter.value.isEmpty ? null : typeFilter.value,
+      );
+      requests.assignAll(result.content);
+      totalPages.value = result.totalPages;
+      totalElements.value = result.totalElements;
+    } catch (e) {
+      Get.snackbar('Lỗi', 'Không thể tải danh sách yêu cầu',
+          backgroundColor: Colors.red[100], colorText: Colors.red[900]);
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  Future<void> refreshList() => fetchRequests(reset: true);
+
+  void changeStatusFilter(String? value) {
+    statusFilter.value = value ?? '';
+    fetchRequests(reset: true);
+  }
+
+  void changeTypeFilter(String? value) {
+    typeFilter.value = value ?? '';
+    fetchRequests(reset: true);
+  }
+
+  void clearFilters() {
+    statusFilter.value = '';
+    typeFilter.value = '';
+    fetchRequests(reset: true);
+  }
+
+  // ─── Request Types ─────────────────────────────────────────────────────────
+
+  Future<void> fetchRequestTypes() async {
+    try {
+      final types = await _service.getRequestTypes();
+      requestTypes.assignAll(types);
+    } catch (e) {
+      // silently fail
+    }
+  }
+
+  // ─── Supporting Data ───────────────────────────────────────────────────────
+
+  Future<void> fetchSupportingData() async {
+    final studentId = _currentStudentId;
+    try {
+      // Fetch student profile, semesters, majors in parallel
+      final results = await Future.wait([
+        _service.getStudentProfile(),
+        _service.getActiveSemesters(),
+        _service.getMajors(),
+      ]);
+
+      final profile = results[0] as User?;
+      if (profile != null) studentProfile.value = profile;
+
+      semesters.assignAll(results[1] as List<SemesterOption>);
+      majors.assignAll(results[2] as List<MajorOption>);
+
+      // Load ALL class sections (no semester filter) for GRADE_APPEAL
+      if (studentId != null) {
+        final allSections = await _service.getAllMyClassSections(studentId);
+        allClassSections.assignAll(allSections);
+        myClassSections.assignAll(allSections);
+      }
+
+      // If student has specialization, pre-load sub-specs for CHANGE_SPECIALIZATION
+      if (profile?.specializationId != null) {
+        final subs = await _service.getSubSpecializations(profile!.specializationId!);
+        subSpecializations.assignAll(subs);
+      }
+      
+      // Load ALL curriculum courses for RETAKE_COURSE and OVERLOAD_STUDY
+      if (profile != null) {
+        final curriculum = await _service.getAllCurriculumCourses(profile);
+        allCurriculumCourses.assignAll(curriculum);
+      }
+    } catch (e) {
+      // silently fail
+    }
+  }
+
+  Future<void> onSemesterChanged(int? semId) async {
+    formSemesterId.value = semId;
+    formCourseId.value = null;
+    myCourses.clear();
+
+    if (semId == null) {
+      // Reset to all class sections
+      myClassSections.assignAll(allClassSections);
+      return;
+    }
+    final studentId = _currentStudentId;
+    if (studentId == null) return;
+    try {
+      loadingCourses.value = true;
+      final courses = await _service.getMyCourses(studentId, semesterId: semId);
+      myCourses.assignAll(courses);
+      // Rebuild class sections for this semester
+      final seen = <String>{};
+      final sections = <ClassSectionOption>[];
+      for (final c in courses) {
+        if (c.className != null && seen.add(c.className!)) {
+          sections.add(ClassSectionOption(className: c.className!, courseName: c.name));
+        }
+      }
+      myClassSections.assignAll(sections);
+    } catch (e) {
+      // ignore
+    } finally {
+      loadingCourses.value = false;
+    }
+  }
+
+  Future<void> onClassSectionChanged(String? className) async {
+    final studentId = _currentStudentId;
+    formClassSectionId.value = className ?? '';
+    formToClassName.value = '';
+    transferTargets.clear();
+    gradeAppealInfo.value = null;
+
+    if (className == null || className.isEmpty) return;
+
+    if (selectedType.value?.value == 'GRADE_APPEAL') {
+      if (studentId == null) return;
+      try {
+        loadingGradeAppealInfo.value = true;
+        gradeAppealInfo.value = await _service.getGradeAppealInfo(studentId, className);
+      } finally {
+        loadingGradeAppealInfo.value = false;
+      }
+      return;
+    }
+
+    if (selectedType.value?.value != 'CHANGE_CLASS') return;
+
+    try {
+      loadingTargets.value = true;
+      final targets = await _service.getTransferTargets(className, studentId: studentId);
+      transferTargets.assignAll(targets);
+    } catch (e) {
+      Get.snackbar('Lỗi', 'Không thể tải danh sách lớp chuyển',
+          backgroundColor: Colors.red[100], colorText: Colors.red[900]);
+    } finally {
+      loadingTargets.value = false;
+    }
+  }
+
+  Future<void> onMajorChanged(MajorOption? major) async {
+    formToMajor.value = major?.name ?? '';
+    formToSpecialization.value = '';
+    specializations.clear();
+    subSpecializations.clear();
+
+    if (major == null) return;
+    try {
+      final specs = await _service.getSpecializations(major.id);
+      specializations.assignAll(specs);
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  Future<void> onSpecializationChanged(SpecializationOption? spec) async {
+    formToSpecialization.value = spec?.name ?? '';
+    formToSubSpecialization.value = '';
+    subSpecializations.clear();
+
+    if (spec == null) return;
+    try {
+      final subs = await _service.getSubSpecializations(spec.id);
+      subSpecializations.assignAll(subs);
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  // ─── Create Form Helpers ───────────────────────────────────────────────────
+
+  void selectType(AcademicRequestType type) {
+    if (!type.canSubmit) {
+      final isFuture = type.startDate != null &&
+          DateTime.tryParse(type.startDate!)?.isAfter(DateTime.now()) == true;
+      Get.snackbar(
+        'Không thể nộp đơn',
+        isFuture ? 'Chưa đến thời gian tiếp nhận loại đơn này' : 'Đã hết hạn nộp loại đơn này',
+        backgroundColor: Colors.orange[100],
+        colorText: Colors.orange[900],
+      );
+      return;
+    }
+    selectedType.value = type;
+    _resetFormFields();
+
+    // For CHANGE_SPECIALIZATION: auto-load sub-specs from student's current specialization
+    if (type.value == 'CHANGE_SPECIALIZATION') {
+      final specId = studentProfile.value?.specializationId;
+      if (specId != null && subSpecializations.isEmpty) {
+        _service.getSubSpecializations(specId).then((subs) {
+          subSpecializations.assignAll(subs);
+        });
+      }
+    }
+  }
+
+  void _resetFormFields() {
+    formReason.value = '';
+    formNote.value = '';
+    formRequestTitle.value = '';
+    formSemesterId.value = null;
+    formCourseId.value = null;
+    formClassSectionId.value = '';
+    formToClassName.value = '';
+    formToMajor.value = '';
+    formToSpecialization.value = '';
+    formToSubSpecialization.value = '';
+    selectedFile.value = null;
+    selectedFileName.value = '';
+    myCourses.clear();
+    transferTargets.clear();
+    gradeAppealInfo.value = null;
+    // Restore class sections to full list
+    myClassSections.assignAll(allClassSections);
+  }
+
+  void backToTypeSelection() {
+    selectedType.value = null;
+    _resetFormFields();
+  }
+
+  Future<void> pickFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['pdf', 'doc', 'docx', 'jpg', 'jpeg', 'png'],
+      withData: false,
+    );
+    if (result != null && result.files.single.path != null) {
+      final file = File(result.files.single.path!);
+      final sizeInMb = await file.length() / (1024 * 1024);
+      if (sizeInMb > 10) {
+        Get.snackbar('Lỗi', 'File không được vượt quá 10MB',
+            backgroundColor: Colors.red[100], colorText: Colors.red[900]);
+        return;
+      }
+      selectedFile.value = file;
+      selectedFileName.value = result.files.single.name;
+    }
+  }
+
+  void removeFile() {
+    selectedFile.value = null;
+    selectedFileName.value = '';
+  }
+
+  // ─── Submit ────────────────────────────────────────────────────────────────
+
+  Future<void> submitRequest() async {
+    final type = selectedType.value;
+    if (type == null) return;
+
+    if (!_validateForm(type.value)) return;
+
+    final payload = CreateAcademicRequestPayload(
+      requestType: type.value,
+      requestTitle: type.value == 'OTHERS' ? formRequestTitle.value.trim() : null,
+      semesterId: formSemesterId.value,
+      courseId: formCourseId.value,
+      classSectionId: formClassSectionId.value.isEmpty ? null : formClassSectionId.value,
+      toClassName: formToClassName.value.isEmpty ? null : formToClassName.value,
+      toMajor: formToMajor.value.isEmpty ? null : formToMajor.value,
+      toSpecialization: formToSpecialization.value.isEmpty ? null : formToSpecialization.value,
+      toSubSpecialization: formToSubSpecialization.value.isEmpty ? null : formToSubSpecialization.value,
+      reason: formReason.value.trim(),
+      note: formNote.value.trim().isEmpty ? null : formNote.value.trim(),
+    );
+
+    try {
+      isSubmitting.value = true;
+      await _service.createRequest(payload, file: selectedFile.value);
+      await refreshList();
+
+      if (Get.currentRoute == AppRoutes.studentAcademicRequestCreate) {
+        Get.back();
+      }
+
+      if (Get.currentRoute != AppRoutes.studentAcademicRequests) {
+        Get.offNamed(AppRoutes.studentAcademicRequests);
+      }
+
+      Get.snackbar('Thành công', 'Gửi yêu cầu thành công',
+          backgroundColor: Colors.green[100], colorText: Colors.green[900]);
+    } catch (e) {
+      String message = 'Không thể gửi yêu cầu';
+      if (e.toString().contains('Exception:')) {
+        message = e.toString().replaceFirst('Exception: ', '');
+      }
+      Get.snackbar('Lỗi', message,
+          backgroundColor: Colors.red[100], colorText: Colors.red[900]);
+    } finally {
+      isSubmitting.value = false;
+    }
+  }
+
+  bool _validateForm(String typeValue) {
+    if (formReason.value.trim().isEmpty) {
+      Get.snackbar('Thiếu thông tin', 'Vui lòng nhập lý do',
+          backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+      return false;
+    }
+
+    switch (typeValue) {
+      case 'OTHERS':
+        if (formRequestTitle.value.trim().isEmpty) {
+          Get.snackbar('Thiếu thông tin', 'Vui lòng nhập tiêu đề yêu cầu',
+              backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+          return false;
+        }
+        break;
+      case 'PAUSE_SEMESTER':
+      case 'ABSENT_REQUEST':
+        if (formSemesterId.value == null) {
+          Get.snackbar('Thiếu thông tin', 'Vui lòng chọn học kỳ',
+              backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+          return false;
+        }
+        break;
+      case 'RETAKE_COURSE':
+      case 'OVERLOAD_STUDY':
+        if (formSemesterId.value == null) {
+          Get.snackbar('Thiếu thông tin', 'Vui lòng chọn học kỳ',
+              backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+          return false;
+        }
+        if (formCourseId.value == null) {
+          Get.snackbar('Thiếu thông tin', 'Vui lòng chọn môn học',
+              backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+          return false;
+        }
+        break;
+      case 'CHANGE_CLASS':
+        if (formSemesterId.value == null) {
+          Get.snackbar('Thiếu thông tin', 'Vui lòng chọn học kỳ',
+              backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+          return false;
+        }
+        if (formClassSectionId.value.isEmpty) {
+          Get.snackbar('Thiếu thông tin', 'Vui lòng chọn lớp học phần hiện tại',
+              backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+          return false;
+        }
+        if (formToClassName.value.isEmpty) {
+          Get.snackbar('Thiếu thông tin', 'Vui lòng chọn lớp muốn chuyển đến',
+              backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+          return false;
+        }
+        break;
+      case 'GRADE_APPEAL':
+        if (formClassSectionId.value.isEmpty) {
+          Get.snackbar('Thiếu thông tin', 'Vui lòng chọn lớp học phần',
+              backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+          return false;
+        }
+        if (gradeAppealInfo.value?.gradesPublished != true) {
+          Get.snackbar('Không thể gửi đơn', 'Điểm thi chưa được công bố. Bạn chưa thể gửi đơn phúc khảo cho lớp này.',
+              backgroundColor: Colors.red[100], colorText: Colors.red[900]);
+          return false;
+        }
+        break;
+      case 'CHANGE_MAJOR':
+        if (formToMajor.value.isEmpty) {
+          Get.snackbar('Thiếu thông tin', 'Vui lòng chọn ngành muốn chuyển',
+              backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+          return false;
+        }
+        break;
+      case 'CHANGE_SPECIALIZATION':
+        if (formToSubSpecialization.value.isEmpty) {
+          Get.snackbar('Thiếu thông tin', 'Vui lòng chọn chuyên ngành hẹp',
+              backgroundColor: Colors.orange[100], colorText: Colors.orange[900]);
+          return false;
+        }
+        break;
+    }
+    return true;
+  }
+
+  // ─── Cancel Request ────────────────────────────────────────────────────────
+
+  Future<void> cancelRequest(int id) async {
+    try {
+      await _service.cancelRequest(id);
+      Get.snackbar('Thành công', 'Đã thu hồi yêu cầu',
+          backgroundColor: Colors.green[100], colorText: Colors.green[900]);
+      await refreshList();
+    } catch (e) {
+      Get.snackbar('Lỗi', 'Không thể thu hồi yêu cầu',
+          backgroundColor: Colors.red[100], colorText: Colors.red[900]);
+    }
+  }
+}

--- a/mobile/lib/features/academic_request/models/academic_request_model.dart
+++ b/mobile/lib/features/academic_request/models/academic_request_model.dart
@@ -1,0 +1,370 @@
+/// Model classes for Academic Request feature (Student)
+/// Maps to /api/v1/academic-requests endpoints
+
+class AcademicRequestType {
+  final String value;
+  final String label;
+  final bool canSubmit;
+  final String? startDate;
+  final String? dueDate;
+  final bool requiresClassSection;
+
+  AcademicRequestType({
+    required this.value,
+    required this.label,
+    required this.canSubmit,
+    this.startDate,
+    this.dueDate,
+    this.requiresClassSection = false,
+  });
+
+  factory AcademicRequestType.fromJson(Map<String, dynamic> json) {
+    return AcademicRequestType(
+      value: json['value'] ?? '',
+      label: json['label'] ?? '',
+      canSubmit: json['canSubmit'] ?? false,
+      startDate: json['startDate'],
+      dueDate: json['dueDate'],
+      requiresClassSection: json['requiresClassSection'] ?? false,
+    );
+  }
+}
+
+class AcademicRequest {
+  final int id;
+  final String requestType;
+  final String requestTypeLabel;
+  final String requestTitle;
+  final String status;
+  final String statusLabel;
+  final String? dueDate;
+  final String createdAt;
+  final String? approverName;
+  final String? approverNote;
+  final String? approvedAt;
+  final String? reason;
+  final String? note;
+  final String? fileUrl;
+  final String? semesterCode;
+  final String? semesterName;
+  final String? courseCode;
+  final String? courseName;
+  final String? className;
+  final String? toClassName;
+  final String? toMajor;
+  final String? toSpecialization;
+  final String? toSubSpecialization;
+  final String? studentName;
+  final String? studentCode;
+
+  AcademicRequest({
+    required this.id,
+    required this.requestType,
+    required this.requestTypeLabel,
+    required this.requestTitle,
+    required this.status,
+    required this.statusLabel,
+    this.dueDate,
+    required this.createdAt,
+    this.approverName,
+    this.approverNote,
+    this.approvedAt,
+    this.reason,
+    this.note,
+    this.fileUrl,
+    this.semesterCode,
+    this.semesterName,
+    this.courseCode,
+    this.courseName,
+    this.className,
+    this.toClassName,
+    this.toMajor,
+    this.toSpecialization,
+    this.toSubSpecialization,
+    this.studentName,
+    this.studentCode,
+  });
+
+  factory AcademicRequest.fromJson(Map<String, dynamic> json) {
+    return AcademicRequest(
+      id: json['id'] ?? 0,
+      requestType: json['requestType'] ?? '',
+      requestTypeLabel: json['requestTypeLabel'] ?? '',
+      requestTitle: json['requestTitle'] ?? '',
+      status: json['status'] ?? '',
+      statusLabel: json['statusLabel'] ?? '',
+      dueDate: json['dueDate'],
+      createdAt: json['createdAt'] ?? '',
+      approverName: json['approverName'],
+      approverNote: json['approverNote'],
+      approvedAt: json['approvedAt'],
+      reason: json['reason'],
+      note: json['note'],
+      fileUrl: json['fileUrl'],
+      semesterCode: json['semesterCode'],
+      semesterName: json['semesterName'],
+      courseCode: json['courseCode'],
+      courseName: json['courseName'],
+      className: json['className'],
+      toClassName: json['toClassName'],
+      toMajor: json['toMajor'],
+      toSpecialization: json['toSpecialization'],
+      toSubSpecialization: json['toSubSpecialization'],
+      studentName: json['studentName'],
+      studentCode: json['studentCode'],
+    );
+  }
+}
+
+class AcademicRequestPage {
+  final List<AcademicRequest> content;
+  final int totalPages;
+  final int totalElements;
+  final int size;
+  final int number;
+
+  AcademicRequestPage({
+    required this.content,
+    required this.totalPages,
+    required this.totalElements,
+    required this.size,
+    required this.number,
+  });
+
+  factory AcademicRequestPage.fromJson(Map<String, dynamic> json) {
+    return AcademicRequestPage(
+      content: (json['content'] as List? ?? [])
+          .map((e) => AcademicRequest.fromJson(e))
+          .toList(),
+      totalPages: json['totalPages'] ?? 0,
+      totalElements: json['totalElements'] ?? 0,
+      size: json['size'] ?? 10,
+      number: json['number'] ?? 0,
+    );
+  }
+}
+
+class GradeAppealInfo {
+  final String className;
+  final bool gradesPublished;
+  final String? gradesPublishedAt;
+
+  GradeAppealInfo({
+    required this.className,
+    required this.gradesPublished,
+    this.gradesPublishedAt,
+  });
+
+  factory GradeAppealInfo.fromJson(Map<String, dynamic> json) {
+    return GradeAppealInfo(
+      className: json['className'] ?? '',
+      gradesPublished: json['gradesPublished'] ?? false,
+      gradesPublishedAt: json['gradesPublishedAt'],
+    );
+  }
+}
+
+/// Payload for creating a new academic request
+class CreateAcademicRequestPayload {
+  final String requestType;
+  final String? requestTitle;
+  final int? semesterId;
+  final int? courseId;
+  final String? classSectionId;
+  final String? toClassName;
+  final String? toMajor;
+  final String? toSpecialization;
+  final String? toSubSpecialization;
+  final String reason;
+  final String? note;
+
+  CreateAcademicRequestPayload({
+    required this.requestType,
+    this.requestTitle,
+    this.semesterId,
+    this.courseId,
+    this.classSectionId,
+    this.toClassName,
+    this.toMajor,
+    this.toSpecialization,
+    this.toSubSpecialization,
+    required this.reason,
+    this.note,
+  });
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{
+      'requestType': requestType,
+      'reason': reason,
+    };
+    if (requestTitle != null) map['requestTitle'] = requestTitle;
+    if (semesterId != null) map['semesterId'] = semesterId;
+    if (courseId != null) map['courseId'] = courseId;
+    if (classSectionId != null) map['classSectionId'] = classSectionId;
+    if (toClassName != null) map['toClassName'] = toClassName;
+    if (toMajor != null) map['toMajor'] = toMajor;
+    if (toSpecialization != null) map['toSpecialization'] = toSpecialization;
+    if (toSubSpecialization != null) map['toSubSpecialization'] = toSubSpecialization;
+    if (note != null && note!.isNotEmpty) map['note'] = note;
+    return map;
+  }
+}
+
+/// Semester option for dropdown
+class SemesterOption {
+  final int id;
+  final String code;
+  final String name;
+
+  SemesterOption({required this.id, required this.code, required this.name});
+
+  factory SemesterOption.fromJson(Map<String, dynamic> json) {
+    return SemesterOption(
+      id: json['id'] ?? 0,
+      code: json['code'] ?? '',
+      name: json['name'] ?? json['semesterName'] ?? '',
+    );
+  }
+
+  @override
+  String toString() => '$code - $name';
+}
+
+/// Course option for dropdown
+class CourseOption {
+  final int id;
+  final String code;
+  final String name;
+  final String? className;
+
+  CourseOption({required this.id, required this.code, required this.name, this.className});
+
+  factory CourseOption.fromJson(Map<String, dynamic> json) {
+    return CourseOption(
+      id: json['courseId'] ?? json['id'] ?? 0,
+      code: json['courseCode'] ?? json['code'] ?? '',
+      name: json['courseName'] ?? json['name'] ?? '',
+      className: json['className'],
+    );
+  }
+
+  @override
+  String toString() => '$code - $name';
+}
+
+/// Class section option for dropdown
+class ClassSectionOption {
+  final String className;
+  final String? courseName;
+  final String? courseCode;
+  final String? semesterName;
+  final String? lecturerName;
+  final String? enrollmentInfo;
+
+  ClassSectionOption({
+    required this.className,
+    this.courseName,
+    this.courseCode,
+    this.semesterName,
+    this.lecturerName,
+    this.enrollmentInfo,
+  });
+
+  factory ClassSectionOption.fromJson(Map<String, dynamic> json) {
+    return ClassSectionOption(
+      className: json['className'] ?? json['name'] ?? '',
+      courseName: json['courseName'],
+      courseCode: json['courseCode'],
+      semesterName: json['semesterName'],
+      lecturerName: json['lecturerName'],
+      enrollmentInfo: json['enrollmentInfo'],
+    );
+  }
+
+  @override
+  String toString() => className;
+}
+
+/// Target class option with conflict details for CHANGE_CLASS
+class ClassSectionTransferTarget {
+  final ClassSectionOption classSection;
+  final bool hasConflict;
+  final List<String> conflictDetails;
+
+  ClassSectionTransferTarget({
+    required this.classSection,
+    this.hasConflict = false,
+    this.conflictDetails = const [],
+  });
+
+  factory ClassSectionTransferTarget.fromJson(Map<String, dynamic> json) {
+    final classSectionJson = json['classSection'];
+    return ClassSectionTransferTarget(
+      classSection: ClassSectionOption.fromJson(
+        classSectionJson is Map<String, dynamic> ? classSectionJson : json,
+      ),
+      hasConflict: json['hasConflict'] ?? false,
+      conflictDetails: (json['conflictDetails'] as List<dynamic>?)?.map((e) => e.toString()).toList() ?? [],
+    );
+  }
+}
+
+/// Major option
+class MajorOption {
+  final int id;
+  final String code;
+  final String name;
+
+  MajorOption({required this.id, required this.code, required this.name});
+
+  factory MajorOption.fromJson(Map<String, dynamic> json) {
+    return MajorOption(
+      id: json['id'] ?? 0,
+      code: json['code'] ?? '',
+      name: json['name'] ?? '',
+    );
+  }
+
+  @override
+  String toString() => name;
+}
+
+/// Specialization option
+class SpecializationOption {
+  final int id;
+  final String code;
+  final String name;
+
+  SpecializationOption({required this.id, required this.code, required this.name});
+
+  factory SpecializationOption.fromJson(Map<String, dynamic> json) {
+    return SpecializationOption(
+      id: json['id'] ?? 0,
+      code: json['code'] ?? '',
+      name: json['name'] ?? '',
+    );
+  }
+
+  @override
+  String toString() => code.isNotEmpty ? '$code - $name' : name;
+}
+
+/// Sub-specialization option
+class SubSpecializationOption {
+  final int id;
+  final String code;
+  final String name;
+
+  SubSpecializationOption({required this.id, required this.code, required this.name});
+
+  factory SubSpecializationOption.fromJson(Map<String, dynamic> json) {
+    return SubSpecializationOption(
+      id: json['id'] ?? 0,
+      code: json['code'] ?? '',
+      name: json['name'] ?? '',
+    );
+  }
+
+  @override
+  String toString() => code.isNotEmpty ? '$code - $name' : name;
+}

--- a/mobile/lib/features/academic_request/services/academic_request_service.dart
+++ b/mobile/lib/features/academic_request/services/academic_request_service.dart
@@ -1,0 +1,278 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:dio/dio.dart';
+import '../../../core/constants/api_constants.dart';
+import '../../../core/services/api_service.dart';
+import '../../auth/models/user_model.dart';
+import '../models/academic_request_model.dart';
+
+/// Service for Academic Request API calls
+class AcademicRequestService {
+  final ApiService _apiService = ApiService();
+
+  /// Get available request types with deadline info
+  Future<List<AcademicRequestType>> getRequestTypes() async {
+    final response = await _apiService.get(ApiConstants.academicRequestTypes);
+    if (response.statusCode == 200) {
+      final list = response.data as List? ?? [];
+      return list.map((e) => AcademicRequestType.fromJson(e)).toList();
+    }
+    return [];
+  }
+
+  /// Get paginated list of student's own requests
+  Future<AcademicRequestPage> getMyRequests({
+    int page = 0,
+    int size = 10,
+    String? status,
+    String? requestType,
+  }) async {
+    final params = <String, dynamic>{'page': page, 'size': size, 'sort': 'createdAt,desc'};
+    if (status != null && status.isNotEmpty) params['status'] = status;
+    if (requestType != null && requestType.isNotEmpty) params['requestType'] = requestType;
+
+    final response = await _apiService.get(
+      ApiConstants.academicRequestMyRequests,
+      queryParameters: params,
+    );
+    if (response.statusCode == 200) {
+      return AcademicRequestPage.fromJson(response.data);
+    }
+    return AcademicRequestPage(content: [], totalPages: 0, totalElements: 0, size: size, number: page);
+  }
+
+  /// Create a new academic request (multipart/form-data)
+  Future<AcademicRequest> createRequest(CreateAcademicRequestPayload payload, {File? file}) async {
+    final formData = FormData.fromMap({
+      'request': MultipartFile.fromString(
+        jsonEncode(payload.toJson()),
+        contentType: DioMediaType('application', 'json'),
+      ),
+      if (file != null)
+        'file': await MultipartFile.fromFile(file.path, filename: file.path.split('/').last),
+    });
+
+    final response = await _apiService.postMultipart(
+      ApiConstants.academicRequests,
+      formData: formData,
+    );
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      return AcademicRequest.fromJson(response.data);
+    }
+    throw Exception('Failed to create request');
+  }
+
+  /// Cancel / withdraw a pending request
+  Future<AcademicRequest> cancelRequest(int id) async {
+    final response = await _apiService.put(
+      '${ApiConstants.academicRequestMyRequests}/$id/cancel',
+    );
+    if (response.statusCode == 200) {
+      return AcademicRequest.fromJson(response.data);
+    }
+    throw Exception('Failed to cancel request');
+  }
+
+  /// Get current student profile from /auth/me
+  Future<User?> getStudentProfile() async {
+    try {
+      final response = await _apiService.get('/api/auth/me');
+      if (response.statusCode == 200) {
+        return User.fromJson(response.data as Map<String, dynamic>);
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  /// Get all semesters
+  Future<List<SemesterOption>> getActiveSemesters() async {
+    try {
+      final response = await _apiService.get('/api/v1/semesters/active');
+      if (response.statusCode == 200) {
+        final list = response.data as List? ?? [];
+        return list.map((e) => SemesterOption.fromJson(e)).toList();
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  /// Get student's enrolled courses
+  /// Endpoint: GET /api/v1/students/{studentId}/courses?semesterId=X
+  Future<List<CourseOption>> getMyCourses(String studentId, {int? semesterId}) async {
+    try {
+      final params = <String, dynamic>{};
+      if (semesterId != null) params['semesterId'] = semesterId;
+      final response = await _apiService.get(
+        '/api/v1/students/$studentId/courses',
+        queryParameters: params,
+      );
+      if (response.statusCode == 200) {
+        final list = response.data as List? ?? [];
+        return list.map((e) => CourseOption.fromJson(e)).toList();
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  /// Get student's class sections derived from enrolled courses
+  /// (Reuses getMyCourses, extracts unique classNames)
+  Future<List<ClassSectionOption>> getMyClassSections(String studentId, {int? semesterId}) async {
+    final courses = await getMyCourses(studentId, semesterId: semesterId);
+    final seen = <String>{};
+    final sections = <ClassSectionOption>[];
+    for (final c in courses) {
+      if (c.className != null && seen.add(c.className!)) {
+        sections.add(ClassSectionOption(className: c.className!, courseName: c.name));
+      }
+    }
+    return sections;
+  }
+
+  /// Get ALL class sections a student is enrolled in (no semester filter)
+  /// Used for GRADE_APPEAL type
+  Future<List<ClassSectionOption>> getAllMyClassSections(String studentId) async {
+    return getMyClassSections(studentId);
+  }
+
+  /// Get grade publication info for GRADE_APPEAL validation
+  Future<GradeAppealInfo?> getGradeAppealInfo(String studentId, String className) async {
+    try {
+      final response = await _apiService.get(
+        '/api/v1/students/$studentId/grades',
+        queryParameters: {'className': className},
+      );
+      if (response.statusCode == 200 && response.data is Map<String, dynamic>) {
+        return GradeAppealInfo.fromJson(response.data as Map<String, dynamic>);
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  /// Get ALL curriculum courses from student's profile (Major, Spec, SubSpec)
+  /// Replicates Web's fetchAllCourses logic for RETAKE_COURSE / OVERLOAD_STUDY
+  Future<List<CourseOption>> getAllCurriculumCourses(User profile) async {
+    try {
+      final allCourses = <CourseOption>[];
+
+      // 1. Fetch courses for major
+      if (profile.majorId != null) {
+        try {
+          final res = await _apiService.get('/api/v1/majors/${profile.majorId}/courses');
+          if (res.statusCode == 200) {
+            final list = res.data as List? ?? [];
+            allCourses.addAll(list.map((e) => CourseOption.fromJson(e)));
+          }
+        } catch (_) {}
+      }
+
+      // 2. Fetch courses for specialization
+      if (profile.specializationId != null) {
+        try {
+          final res = await _apiService.get('/api/v1/specializations/${profile.specializationId}/courses');
+          if (res.statusCode == 200) {
+            final list = res.data as List? ?? [];
+            allCourses.addAll(list.map((e) => CourseOption.fromJson(e)));
+          }
+        } catch (_) {}
+      }
+
+      // 3. Fetch courses for sub-specialization
+      if (profile.subSpecializationId != null) {
+        try {
+          final res = await _apiService.get('/api/v1/sub-specializations/${profile.subSpecializationId}/courses');
+          if (res.statusCode == 200) {
+            final list = res.data as List? ?? [];
+            allCourses.addAll(list.map((e) => CourseOption.fromJson(e)));
+          }
+        } catch (_) {}
+      }
+
+      // Remove duplicates by ID and sort by code
+      final uniqueMap = <int, CourseOption>{};
+      for (final c in allCourses) {
+        uniqueMap[c.id] = c;
+      }
+      
+      final sortedCourses = uniqueMap.values.toList()
+        ..sort((a, b) => a.code.compareTo(b.code));
+        
+      return sortedCourses;
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// Get transfer candidate classes for CHANGE_CLASS
+  Future<List<ClassSectionTransferTarget>> getTransferTargets(String className, {String? studentId}) async {
+    try {
+      final hasStudentId = studentId != null && studentId.trim().isNotEmpty;
+      final response = await _apiService.get(
+        hasStudentId
+            ? '/api/v1/class-sections/$className/transfer-targets-with-conflict'
+            : '/api/v1/class-sections/$className/transfer-targets',
+        queryParameters: hasStudentId ? {'studentId': studentId} : null,
+      );
+      if (response.statusCode == 200) {
+        final list = response.data as List? ?? [];
+        return list.map((e) => ClassSectionTransferTarget.fromJson(e)).toList();
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  /// Get all majors
+  Future<List<MajorOption>> getMajors() async {
+    try {
+      final response = await _apiService.get('/api/majors', queryParameters: {'size': 200, 'status': 'ACTIVE'});
+      if (response.statusCode == 200) {
+        List list = [];
+        if (response.data is List) {
+          list = response.data;
+        } else if (response.data is Map && response.data['content'] is List) {
+          list = response.data['content'];
+        }
+        return list.map((e) => MajorOption.fromJson(e)).toList();
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  /// Get specializations by major ID
+  Future<List<SpecializationOption>> getSpecializations(int majorId) async {
+    try {
+      final response = await _apiService.get(
+        '/api/specializations/by-major/$majorId',
+        queryParameters: {'size': 100, 'status': 'ACTIVE'},
+      );
+      if (response.statusCode == 200) {
+        List list = [];
+        if (response.data is List) {
+          list = response.data;
+        } else if (response.data is Map && response.data['content'] is List) {
+          list = response.data['content'];
+        }
+        return list.map((e) => SpecializationOption.fromJson(e)).toList();
+      }
+    } catch (_) {}
+    return [];
+  }
+
+  /// Get sub-specializations by specialization ID
+  Future<List<SubSpecializationOption>> getSubSpecializations(int specId) async {
+    try {
+      final response = await _apiService.get(
+        '/api/sub-specializations/by-specialization/$specId',
+      );
+      if (response.statusCode == 200) {
+        List list = [];
+        if (response.data is List) {
+          list = response.data;
+        } else if (response.data is Map && response.data['content'] is List) {
+          list = response.data['content'];
+        }
+        return list.map((e) => SubSpecializationOption.fromJson(e)).toList();
+      }
+    } catch (_) {}
+    return [];
+  }
+}

--- a/mobile/lib/features/academic_request/views/academic_request_create_screen.dart
+++ b/mobile/lib/features/academic_request/views/academic_request_create_screen.dart
@@ -1,0 +1,844 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../../core/widgets/app_background.dart';
+import '../controllers/academic_request_controller.dart';
+import '../models/academic_request_model.dart';
+
+/// 2-step academic request creation screen
+/// Step 1: Choose request type
+/// Step 2: Fill dynamic form per type
+class AcademicRequestCreateScreen extends StatefulWidget {
+  const AcademicRequestCreateScreen({super.key});
+
+  @override
+  State<AcademicRequestCreateScreen> createState() => _AcademicRequestCreateScreenState();
+}
+
+class _AcademicRequestCreateScreenState extends State<AcademicRequestCreateScreen> {
+  late final AcademicRequestController controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = Get.find<AcademicRequestController>();
+    controller.backToTypeSelection();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: AppBackground(
+        child: SafeArea(
+          child: Column(
+            children: [
+              _buildHeader(controller),
+              Expanded(
+                child: Obx(() {
+                  if (controller.selectedType.value == null) {
+                    return _TypeSelectionStep(controller: controller);
+                  }
+                  return _FormStep(controller: controller);
+                }),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(AcademicRequestController controller) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 12),
+      child: Row(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12),
+              boxShadow: [
+                BoxShadow(color: Colors.black.withOpacity(0.05), blurRadius: 8, offset: const Offset(0, 2)),
+              ],
+            ),
+            child: IconButton(
+              icon: const Icon(Icons.arrow_back_ios_new_rounded, size: 20),
+              color: const Color(0xFF2D3436),
+              onPressed: () {
+                if (controller.selectedType.value != null) {
+                  controller.backToTypeSelection();
+                } else {
+                  Get.back();
+                }
+              },
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Obx(() => Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  controller.selectedType.value == null ? 'Chọn loại yêu cầu' : 'Thông tin yêu cầu',
+                  style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Color(0xFF2D3436)),
+                ),
+                if (controller.selectedType.value != null)
+                  Text(controller.selectedType.value!.label,
+                      style: TextStyle(fontSize: 13, color: Colors.grey[600])),
+              ],
+            )),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── Step 1: Type Selection ───────────────────────────────────────────────────
+
+class _TypeSelectionStep extends StatelessWidget {
+  final AcademicRequestController controller;
+  const _TypeSelectionStep({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      if (controller.requestTypes.isEmpty) {
+        return const Center(child: CircularProgressIndicator(color: AppColors.primaryOrange));
+      }
+      return ListView.builder(
+        padding: const EdgeInsets.fromLTRB(16, 4, 16, 20),
+        itemCount: controller.requestTypes.length,
+        itemBuilder: (_, i) {
+          final type = controller.requestTypes[i];
+          return _TypeCard(type: type, onTap: () => controller.selectType(type));
+        },
+      );
+    });
+  }
+}
+
+class _TypeCard extends StatelessWidget {
+  final AcademicRequestType type;
+  final VoidCallback onTap;
+
+  const _TypeCard({required this.type, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = type.canSubmit;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 10),
+      decoration: BoxDecoration(
+        color: enabled ? Colors.white : Colors.grey[100],
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: enabled ? Colors.transparent : Colors.grey[300]!, width: 1),
+        boxShadow: enabled
+            ? [BoxShadow(color: Colors.black.withOpacity(0.04), blurRadius: 8, offset: const Offset(0, 3))]
+            : null,
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(14),
+          onTap: enabled ? onTap : () => controller.selectType(type),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: enabled ? const Color(0xFFFFF0E0) : Colors.grey[200],
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(Icons.article_outlined,
+                      color: enabled ? AppColors.primaryOrange : Colors.grey[400], size: 20),
+                ),
+                const SizedBox(width: 14),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(type.label,
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            color: enabled ? const Color(0xFF2D3436) : Colors.grey[500],
+                          )),
+                      if (type.dueDate != null) ...[
+                        const SizedBox(height: 3),
+                        Text(
+                          type.canSubmit ? 'Hạn: ${type.dueDate}' : 'Đã hết hạn - ${type.dueDate}',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: type.canSubmit ? Colors.grey[500] : Colors.red[400],
+                          ),
+                        ),
+                      ] else if (type.startDate != null && !type.canSubmit) ...[
+                        const SizedBox(height: 3),
+                        Text('Bắt đầu từ: ${type.startDate}',
+                            style: TextStyle(fontSize: 11, color: Colors.blue[400])),
+                      ],
+                    ],
+                  ),
+                ),
+                if (enabled)
+                  const Icon(Icons.chevron_right_rounded, color: AppColors.primaryOrange),
+                if (!enabled)
+                  Icon(Icons.lock_outline_rounded, color: Colors.grey[400], size: 18),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // expose controller to inner widget
+  AcademicRequestController get controller => Get.find<AcademicRequestController>();
+}
+
+// ─── Step 2: Dynamic Form ─────────────────────────────────────────────────────
+
+class _FormStep extends StatelessWidget {
+  final AcademicRequestController controller;
+  const _FormStep({required this.controller});
+
+  String _buildTransferTargetLabel(ClassSectionTransferTarget target) {
+    final section = target.classSection;
+    final details = <String>[
+      if ((section.courseCode ?? '').isNotEmpty && (section.courseName ?? '').isNotEmpty)
+        '${section.courseCode} - ${section.courseName}',
+      if ((section.courseCode ?? '').isEmpty && (section.courseName ?? '').isNotEmpty)
+        section.courseName!,
+      if ((section.enrollmentInfo ?? '').isNotEmpty) 'Sĩ số: ${section.enrollmentInfo}',
+    ];
+
+    final baseLabel = details.isEmpty
+        ? section.className
+        : '${section.className}\n${details.join(' | ')}';
+
+    return baseLabel;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 20),
+            child: Obx(() {
+              final type = controller.selectedType.value!.value;
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Type-specific fields
+                  ..._buildFieldsForType(type),
+                  const SizedBox(height: 16),
+
+                  // Reason (always required)
+                  _SectionLabel('Lý do *'),
+                  _TextInputField(
+                    hint: 'Nhập lý do của bạn...',
+                    maxLines: 4,
+                    value: controller.formReason.value,
+                    onChanged: (v) => controller.formReason.value = v,
+                  ),
+                  const SizedBox(height: 16),
+
+                  // Optional note for OTHERS type
+                  if (type == 'OTHERS') ...[
+                    _SectionLabel('Ghi chú'),
+                    _TextInputField(
+                      hint: 'Ghi chú thêm (không bắt buộc)',
+                      maxLines: 3,
+                      value: controller.formNote.value,
+                      onChanged: (v) => controller.formNote.value = v,
+                    ),
+                    const SizedBox(height: 16),
+                  ],
+
+                  // File attachment
+                  _SectionLabel('File đính kèm (tùy chọn, tối đa 10MB)'),
+                  _buildFileSection(),
+                  const SizedBox(height: 24),
+                ],
+              );
+            }),
+          ),
+        ),
+        // Submit button
+        _buildSubmitButton(),
+      ],
+    );
+  }
+
+  List<Widget> _buildFieldsForType(String type) {
+    final fields = <Widget>[];
+
+    // Semester dropdown (not needed for GRADE_APPEAL)
+    if (['PAUSE_SEMESTER', 'RETAKE_COURSE', 'CHANGE_CLASS', 'OVERLOAD_STUDY', 'ABSENT_REQUEST'].contains(type)) {
+      fields.add(_SectionLabel('Học kỳ *'));
+      fields.add(_buildSemesterDropdown());
+      fields.add(const SizedBox(height: 16));
+    }
+
+    // Course dropdown (for RETAKE_COURSE, OVERLOAD_STUDY)
+    if (['RETAKE_COURSE', 'OVERLOAD_STUDY'].contains(type)) {
+      fields.add(_SectionLabel('Môn học *'));
+      fields.add(_buildCourseDropdown(type));
+      fields.add(const SizedBox(height: 16));
+    }
+
+    // Class section dropdown
+    if (['CHANGE_CLASS', 'GRADE_APPEAL'].contains(type)) {
+      final label = type == 'GRADE_APPEAL' ? 'Lớp học phần muốn phúc khảo *' : 'Lớp học phần *';
+      fields.add(_SectionLabel(label));
+      fields.add(_buildClassSectionDropdown(type));
+      if (type == 'GRADE_APPEAL') {
+        fields.add(const SizedBox(height: 8));
+        fields.add(_buildGradeAppealInfo());
+      }
+      fields.add(const SizedBox(height: 16));
+    }
+
+    // Target class (for CHANGE_CLASS)
+    if (type == 'CHANGE_CLASS') {
+      fields.add(_SectionLabel('Lớp muốn chuyển đến *'));
+      fields.add(_buildTransferTargetDropdown());
+      fields.add(const SizedBox(height: 16));
+    }
+
+    // Major dropdown (for CHANGE_MAJOR)
+    if (type == 'CHANGE_MAJOR') {
+      // Show current major/specialization info
+      final profile = controller.studentProfile.value;
+      fields.add(_buildCurrentInfoCard(
+        items: [
+          _InfoItem('Ngành hiện tại', profile?.major ?? 'N/A'),
+          _InfoItem('Chuyên ngành hiện tại', profile?.specialization ?? 'N/A'),
+        ],
+      ));
+      fields.add(const SizedBox(height: 16));
+
+      fields.add(_SectionLabel('Ngành muốn chuyển *'));
+      fields.add(_buildMajorDropdown());
+      fields.add(const SizedBox(height: 16));
+
+      if (controller.majors.isNotEmpty && controller.formToMajor.value.isNotEmpty) {
+        fields.add(_SectionLabel('Chuyên ngành muốn chuyển *'));
+        fields.add(_buildSpecializationDropdown());
+        fields.add(const SizedBox(height: 16));
+      }
+    }
+
+    // Sub-specialization (for CHANGE_SPECIALIZATION)
+    if (type == 'CHANGE_SPECIALIZATION') {
+      // Show current sub-specialization info
+      final profile = controller.studentProfile.value;
+      fields.add(_buildCurrentInfoCard(
+        items: [
+          _InfoItem('Chuyên ngành hẹp hiện tại', profile?.subSpecialization ?? 'Chưa được thêm vào chuyên ngành hẹp'),
+          _InfoItem('Chuyên ngành', profile?.specialization ?? 'N/A'),
+        ],
+        note: '* Bạn chỉ có thể chuyển giữa các chuyên ngành hẹp trong cùng chuyên ngành',
+      ));
+      fields.add(const SizedBox(height: 16));
+
+      fields.add(_SectionLabel('Chuyên ngành hẹp muốn chuyển *'));
+      fields.add(_buildSubSpecializationDropdown());
+      fields.add(const SizedBox(height: 16));
+    }
+
+    // Request title for OTHERS
+    if (type == 'OTHERS') {
+      fields.insert(0, _SectionLabel('Tiêu đề yêu cầu *'));
+      fields.insert(1, _TextInputField(
+        hint: 'Nhập tiêu đề...',
+        value: controller.formRequestTitle.value,
+        onChanged: (v) => controller.formRequestTitle.value = v,
+      ));
+      fields.insert(2, const SizedBox(height: 16));
+    }
+
+    return fields;
+  }
+
+  Widget _buildSemesterDropdown() {
+    return Obx(() => _DropdownField<SemesterOption>(
+      hint: 'Chọn học kỳ',
+      items: controller.semesters,
+      value: controller.semesters.firstWhereOrNull((s) => s.id == controller.formSemesterId.value),
+      labelOf: (s) => '${s.code} - ${s.name}',
+      onChanged: (s) => controller.onSemesterChanged(s?.id),
+    ));
+  }
+
+  Widget _buildCourseDropdown(String type) {
+    return Obx(() {
+      if (controller.loadingCourses.value) {
+        return const Center(child: Padding(padding: EdgeInsets.all(12), child: CircularProgressIndicator(strokeWidth: 2)));
+      }
+      
+      final useCurriculumCourses = ['RETAKE_COURSE', 'OVERLOAD_STUDY'].contains(type);
+      final courses = useCurriculumCourses ? controller.allCurriculumCourses : controller.myCourses;
+      final hint = useCurriculumCourses 
+          ? 'Chọn môn học' 
+          : (controller.formSemesterId.value == null ? 'Chọn học kỳ trước' : 'Chọn môn học');
+      final enabled = useCurriculumCourses || controller.formSemesterId.value != null;
+
+      return _DropdownField<CourseOption>(
+        hint: hint,
+        items: courses,
+        value: courses.firstWhereOrNull((c) => c.id == controller.formCourseId.value),
+        labelOf: (c) => '${c.code} - ${c.name}',
+        onChanged: (c) => controller.formCourseId.value = c?.id,
+        enabled: enabled,
+      );
+    });
+  }
+
+  Widget _buildClassSectionDropdown(String type) {
+    return Obx(() {
+      // GRADE_APPEAL uses allClassSections (no semester filter)
+      // CHANGE_CLASS uses myClassSections (semester-filtered)
+      final sections = type == 'GRADE_APPEAL'
+          ? controller.allClassSections
+          : controller.myClassSections;
+      return _DropdownField<ClassSectionOption>(
+        hint: 'Chọn lớp học phần',
+        items: sections,
+        value: sections.firstWhereOrNull((c) => c.className == controller.formClassSectionId.value),
+        labelOf: (c) => c.courseName != null ? '${c.className} - ${c.courseName}' : c.className,
+        onChanged: (c) => controller.onClassSectionChanged(c?.className),
+      );
+    });
+  }
+
+  Widget _buildTransferTargetDropdown() {
+    return Obx(() {
+      if (controller.loadingTargets.value) {
+        return const Center(child: Padding(padding: EdgeInsets.all(12), child: CircularProgressIndicator(strokeWidth: 2)));
+      }
+      
+      final selectedTarget = controller.transferTargets.firstWhereOrNull((c) => c.classSection.className == controller.formToClassName.value);
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _DropdownField<ClassSectionTransferTarget>(
+            hint: controller.formClassSectionId.value.isEmpty ? 'Chọn lớp hiện tại trước' : 'Chọn lớp muốn chuyển',
+            items: controller.transferTargets,
+            value: selectedTarget,
+            labelOf: _buildTransferTargetLabel,
+            onChanged: (c) => controller.formToClassName.value = c?.classSection.className ?? '',
+            enabled: controller.formClassSectionId.value.isNotEmpty,
+            // Only apply red text if it has a conflict
+            itemTextStyle: (c) => c.hasConflict ? const TextStyle(color: Colors.red) : null,
+          ),
+          
+          if (selectedTarget != null && selectedTarget.hasConflict) ...[
+            const SizedBox(height: 8),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.orange.shade50,
+                border: Border.all(color: Colors.orange.shade200),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Icon(Icons.warning_amber_rounded, size: 18, color: Colors.orange.shade800),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          'Cảnh báo xung đột thời gian:',
+                          style: TextStyle(fontWeight: FontWeight.bold, color: Colors.orange.shade900),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  ...selectedTarget.conflictDetails.map((detail) => Padding(
+                    padding: const EdgeInsets.only(bottom: 4, left: 26),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('• ', style: TextStyle(color: Colors.orange.shade800)),
+                        Expanded(child: Text(detail, style: TextStyle(color: Colors.orange.shade800, fontSize: 13))),
+                      ],
+                    ),
+                  )),
+                  const SizedBox(height: 8),
+                  Text(
+                    '* Bạn vẫn có thể gửi yêu cầu, nhưng khả năng được duyệt sẽ thấp hơn nếu có xung đột.',
+                    style: TextStyle(fontStyle: FontStyle.italic, color: Colors.orange.shade700, fontSize: 12),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      );
+    });
+  }
+
+  Widget _buildGradeAppealInfo() {
+    return Obx(() {
+      if (controller.formClassSectionId.value.isEmpty) {
+        return const SizedBox.shrink();
+      }
+
+      if (controller.loadingGradeAppealInfo.value) {
+        return Row(
+          children: [
+            SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2, color: Colors.grey[600]),
+            ),
+            const SizedBox(width: 8),
+            Text('Đang kiểm tra trạng thái điểm...', style: TextStyle(fontSize: 13, color: Colors.grey[600])),
+          ],
+        );
+      }
+
+      final info = controller.gradeAppealInfo.value;
+      if (info == null) {
+        return const SizedBox.shrink();
+      }
+
+      final isPublished = info.gradesPublished;
+      return Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: isPublished ? Colors.blue[50] : Colors.red[50],
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: isPublished ? Colors.blue[200]! : Colors.red[200]!),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              isPublished ? Icons.check_circle_outline_rounded : Icons.error_outline_rounded,
+              size: 18,
+              color: isPublished ? Colors.blue[800] : Colors.red[800],
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                isPublished
+                    ? 'Điểm đã được công bố. Bạn có thể gửi đơn phúc khảo cho lớp này.'
+                    : 'Điểm thi chưa được công bố. Bạn chưa thể gửi đơn phúc khảo cho lớp này.',
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: isPublished ? Colors.blue[800] : Colors.red[800],
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    });
+  }
+
+  Widget _buildMajorDropdown() {
+    return Obx(() => _DropdownField<MajorOption>(
+      hint: 'Chọn ngành',
+      items: controller.majors,
+      value: controller.majors.firstWhereOrNull((m) => m.name == controller.formToMajor.value),
+      labelOf: (m) => m.code.isNotEmpty ? '${m.code} - ${m.name}' : m.name,
+      onChanged: controller.onMajorChanged,
+    ));
+  }
+
+  Widget _buildSpecializationDropdown() {
+    return Obx(() => _DropdownField<SpecializationOption>(
+      hint: 'Chọn chuyên ngành',
+      items: controller.specializations,
+      value: controller.specializations.firstWhereOrNull((s) => s.name == controller.formToSpecialization.value),
+      labelOf: (s) => s.code.isNotEmpty ? '${s.code} - ${s.name}' : s.name,
+      onChanged: controller.onSpecializationChanged,
+      enabled: controller.formToMajor.value.isNotEmpty,
+    ));
+  }
+
+  Widget _buildSubSpecializationDropdown() {
+    return Obx(() {
+      final currentSubSpecialization = controller.studentProfile.value?.subSpecialization;
+      final options = controller.subSpecializations
+          .where((s) => s.name != currentSubSpecialization)
+          .toList();
+
+      return _DropdownField<SubSpecializationOption>(
+        hint: options.isEmpty ? 'Không có chuyên ngành hẹp phù hợp' : 'Chọn chuyên ngành hẹp',
+        items: options,
+        value: options.firstWhereOrNull((s) => s.name == controller.formToSubSpecialization.value),
+        labelOf: (s) => s.code.isNotEmpty ? '${s.code} - ${s.name}' : s.name,
+        onChanged: (s) => controller.formToSubSpecialization.value = s?.name ?? '',
+        enabled: options.isNotEmpty,
+      );
+    });
+  }
+
+  Widget _buildFileSection() {
+    return Obx(() => controller.selectedFile.value == null
+        ? GestureDetector(
+            onTap: controller.pickFile,
+            child: Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: Colors.grey[300]!, style: BorderStyle.solid),
+              ),
+              child: Row(
+                children: [
+                  Icon(Icons.attach_file_rounded, color: Colors.grey[500]),
+                  const SizedBox(width: 12),
+                  Text('Chọn file đính kèm', style: TextStyle(color: Colors.grey[600])),
+                ],
+              ),
+            ),
+          )
+        : Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.orange[50],
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: AppColors.primaryOrange.withOpacity(0.3)),
+            ),
+            child: Row(
+              children: [
+                const Icon(Icons.attach_file_rounded, color: AppColors.primaryOrange, size: 18),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(controller.selectedFileName.value,
+                      style: const TextStyle(color: AppColors.primaryOrange, fontSize: 13),
+                      overflow: TextOverflow.ellipsis),
+                ),
+                GestureDetector(
+                  onTap: controller.removeFile,
+                  child: const Icon(Icons.close_rounded, color: AppColors.primaryOrange, size: 18),
+                ),
+              ],
+            ),
+          ));
+  }
+
+  Widget _buildCurrentInfoCard({required List<_InfoItem> items, String? note}) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.blue[50],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.blue[200]!),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.info_outline_rounded, size: 14, color: Colors.blue[700]),
+              const SizedBox(width: 6),
+              Text('Thông tin hiện tại', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: Colors.blue[700])),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ...items.map((item) => Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(item.label, style: TextStyle(fontSize: 12, color: Colors.grey[600])),
+                const SizedBox(height: 2),
+                Text(item.value, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500)),
+              ],
+            ),
+          )),
+          if (note != null) ...[
+            const SizedBox(height: 6),
+            Text(note, style: TextStyle(fontSize: 11, color: Colors.blue[600], fontStyle: FontStyle.italic)),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSubmitButton() {
+    return Obx(() => Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+      color: Colors.white,
+      child: SizedBox(
+        width: double.infinity,
+        child: ElevatedButton(
+          onPressed: controller.isSubmitting.value ? null : controller.submitRequest,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.primaryOrange,
+            disabledBackgroundColor: Colors.grey[300],
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+          ),
+          child: controller.isSubmitting.value
+              ? const SizedBox(
+                  height: 20, width: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+              : const Text('Gửi yêu cầu',
+                  style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16)),
+        ),
+      ),
+    ));
+  }
+}
+
+class _InfoItem {
+  final String label;
+  final String value;
+  const _InfoItem(this.label, this.value);
+}
+
+// ─── Generic Dropdown Widget ──────────────────────────────────────────────────
+
+class _DropdownField<T> extends StatelessWidget {
+  final String hint;
+  final List<T> items;
+  final T? value;
+  final String Function(T) labelOf;
+  final void Function(T?) onChanged;
+  final bool enabled;
+  final TextStyle? Function(T)? itemTextStyle;
+
+  const _DropdownField({
+    required this.hint,
+    required this.items,
+    required this.value,
+    required this.labelOf,
+    required this.onChanged,
+    this.enabled = true,
+    this.itemTextStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Widget buildItemLabel(T item) {
+      final customStyle = itemTextStyle?.call(item);
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        child: Text(
+          labelOf(item),
+          style: customStyle ?? const TextStyle(fontSize: 14, color: Color(0xFF2D3436)),
+        ),
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14),
+      decoration: BoxDecoration(
+        color: enabled ? Colors.white : Colors.grey[100],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey[300]!),
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<T>(
+          hint: Text(hint, style: TextStyle(color: Colors.grey[500], fontSize: 14)),
+          value: value,
+          isExpanded: true,
+          itemHeight: null, // Allow multiline items
+          items: items.map((item) {
+            return DropdownMenuItem<T>(
+              value: item,
+              child: buildItemLabel(item),
+            );
+          }).toList(),
+          selectedItemBuilder: (_) => items.map(buildItemLabel).toList(),
+          onChanged: enabled ? onChanged : null,
+          dropdownColor: Colors.white,
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Text Input Field ─────────────────────────────────────────────────────────
+
+class _TextInputField extends StatefulWidget {
+  final String hint;
+  final int maxLines;
+  final String value;
+  final void Function(String) onChanged;
+
+  const _TextInputField({
+    required this.hint,
+    required this.value,
+    required this.onChanged,
+    this.maxLines = 1,
+  });
+
+  @override
+  State<_TextInputField> createState() => _TextInputFieldState();
+}
+
+class _TextInputFieldState extends State<_TextInputField> {
+  late TextEditingController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = TextEditingController(text: widget.value);
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: _ctrl,
+      maxLines: widget.maxLines,
+      onChanged: widget.onChanged,
+      decoration: InputDecoration(
+        hintText: widget.hint,
+        hintStyle: TextStyle(color: Colors.grey[500], fontSize: 14),
+        filled: true,
+        fillColor: Colors.white,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide(color: Colors.grey[300]!),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide(color: Colors.grey[300]!),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.primaryOrange, width: 1.5),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  const _SectionLabel(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(text,
+          style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: Color(0xFF2D3436))),
+    );
+  }
+}

--- a/mobile/lib/features/academic_request/views/academic_request_list_screen.dart
+++ b/mobile/lib/features/academic_request/views/academic_request_list_screen.dart
@@ -1,0 +1,501 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../../core/widgets/app_background.dart';
+import '../controllers/academic_request_controller.dart';
+import '../models/academic_request_model.dart';
+import '../widgets/academic_request_status_badge.dart';
+
+/// Screen showing the student's academic request list
+class AcademicRequestListScreen extends StatelessWidget {
+  const AcademicRequestListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.isRegistered<AcademicRequestController>()
+        ? Get.find<AcademicRequestController>()
+        : Get.put(AcademicRequestController());
+
+    return Scaffold(
+      body: AppBackground(
+        child: SafeArea(
+          child: Column(
+            children: [
+              _buildHeader(controller),
+              _buildFilterBar(controller),
+              Expanded(
+                child: Obx(() {
+                  if (controller.isLoading.value && controller.requests.isEmpty) {
+                    return const Center(
+                      child: CircularProgressIndicator(color: AppColors.primaryOrange),
+                    );
+                  }
+                  if (controller.requests.isEmpty) {
+                    return _buildEmptyState(controller);
+                  }
+                  return RefreshIndicator(
+                    onRefresh: controller.refreshList,
+                    color: AppColors.primaryOrange,
+                    child: ListView.builder(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 100),
+                      physics: const BouncingScrollPhysics(),
+                      itemCount: controller.requests.length,
+                      itemBuilder: (context, index) {
+                        final req = controller.requests[index];
+                        return _AcademicRequestCard(
+                          request: req,
+                          onTap: () => _showDetailSheet(context, req, controller),
+                        );
+                      },
+                    ),
+                  );
+                }),
+              ),
+            ],
+          ),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        backgroundColor: AppColors.primaryOrange,
+        onPressed: () => Get.toNamed('/student/academic-requests/create'),
+        icon: const Icon(Icons.add, color: Colors.white),
+        label: const Text('Tạo yêu cầu', style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+      ),
+    );
+  }
+
+  Widget _buildHeader(AcademicRequestController controller) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 12),
+      child: Row(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.05),
+                  blurRadius: 8,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: IconButton(
+              icon: const Icon(Icons.arrow_back_ios_new_rounded, size: 20),
+              onPressed: () => Get.back(),
+              color: const Color(0xFF2D3436),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Yêu Cầu Học Thuật',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xFF2D3436),
+                    letterSpacing: -0.5,
+                  ),
+                ),
+                Obx(() => Text(
+                  '${controller.totalElements.value} yêu cầu',
+                  style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+                )),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterBar(AcademicRequestController controller) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Obx(() => Row(
+          children: [
+            _FilterChip(label: 'Tất cả', isSelected: controller.statusFilter.value == '',
+                onTap: () => controller.changeStatusFilter('')),
+            const SizedBox(width: 8),
+            _FilterChip(label: 'Chờ xử lý', color: Colors.amber,
+                isSelected: controller.statusFilter.value == 'PENDING',
+                onTap: () => controller.changeStatusFilter('PENDING')),
+            const SizedBox(width: 8),
+            _FilterChip(label: 'Đã duyệt', color: Colors.green,
+                isSelected: controller.statusFilter.value == 'APPROVED',
+                onTap: () => controller.changeStatusFilter('APPROVED')),
+            const SizedBox(width: 8),
+            _FilterChip(label: 'Từ chối', color: Colors.red,
+                isSelected: controller.statusFilter.value == 'REJECTED',
+                onTap: () => controller.changeStatusFilter('REJECTED')),
+            const SizedBox(width: 8),
+            _FilterChip(label: 'Đã hủy', color: Colors.grey,
+                isSelected: controller.statusFilter.value == 'CANCELLED',
+                onTap: () => controller.changeStatusFilter('CANCELLED')),
+          ],
+        )),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(AcademicRequestController controller) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(40),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.inbox_outlined, size: 80, color: Colors.grey[300]),
+            const SizedBox(height: 16),
+            Text(
+              controller.statusFilter.value.isNotEmpty
+                  ? 'Không có yêu cầu nào với trạng thái này'
+                  : 'Chưa có yêu cầu nào.\nNhấn "Tạo yêu cầu" để bắt đầu!',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 15, color: Colors.grey[500]),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showDetailSheet(
+      BuildContext context, AcademicRequest req, AcademicRequestController controller) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => _DetailSheet(request: req, controller: controller),
+    );
+  }
+}
+
+// ─── Request Card ─────────────────────────────────────────────────────────────
+
+class _AcademicRequestCard extends StatelessWidget {
+  final AcademicRequest request;
+  final VoidCallback onTap;
+
+  const _AcademicRequestCard({required this.request, required this.onTap});
+
+  String _formatDate(String? dateStr) {
+    if (dateStr == null || dateStr.isEmpty) return '—';
+    try {
+      return DateFormat('dd/MM/yyyy').format(DateTime.parse(dateStr));
+    } catch (_) {
+      return dateStr;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(16),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Row: type label + status badge
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFFFF0E0),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        request.requestTypeLabel,
+                        style: const TextStyle(
+                          fontSize: 11,
+                          color: AppColors.primaryOrange,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    const Spacer(),
+                    AcademicRequestStatusBadge(
+                      status: request.status,
+                      label: request.statusLabel,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                // Title
+                Text(
+                  request.requestTitle,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF2D3436),
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 8),
+                // Footer: dates
+                Row(
+                  children: [
+                    Icon(Icons.calendar_today_rounded, size: 12, color: Colors.grey[500]),
+                    const SizedBox(width: 4),
+                    Text(
+                      'Ngày tạo: ${_formatDate(request.createdAt)}',
+                      style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+                    ),
+                    if (request.dueDate != null) ...[
+                      const SizedBox(width: 12),
+                      Icon(Icons.timer_outlined, size: 12, color: Colors.grey[500]),
+                      const SizedBox(width: 4),
+                      Text(
+                        'Hạn: ${request.dueDate}',
+                        style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+                      ),
+                    ],
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Detail Bottom Sheet ──────────────────────────────────────────────────────
+
+class _DetailSheet extends StatelessWidget {
+  final AcademicRequest request;
+  final AcademicRequestController controller;
+
+  const _DetailSheet({required this.request, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      initialChildSize: 0.6,
+      maxChildSize: 0.92,
+      minChildSize: 0.4,
+      expand: false,
+      builder: (_, scrollController) => Container(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Handle
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Colors.grey[300],
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            // Title row
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    request.requestTitle,
+                    style: const TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.bold,
+                      color: Color(0xFF2D3436),
+                    ),
+                  ),
+                ),
+                AcademicRequestStatusBadge(status: request.status, label: request.statusLabel),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(request.requestTypeLabel,
+                style: TextStyle(fontSize: 13, color: Colors.grey[600])),
+            const Divider(height: 24),
+            Expanded(
+              child: ListView(
+                controller: scrollController,
+                children: [
+                  if (request.semesterName != null)
+                    _DetailRow('Học kỳ', request.semesterName!),
+                  if (request.courseName != null)
+                    _DetailRow('Môn học', '${request.courseCode ?? ''} - ${request.courseName}'),
+                  if (request.className != null)
+                    _DetailRow('Lớp học phần', request.className!),
+                  if (request.toClassName != null)
+                    _DetailRow('Lớp muốn chuyển', request.toClassName!),
+                  if (request.toMajor != null)
+                    _DetailRow('Ngành muốn chuyển', request.toMajor!),
+                  if (request.toSpecialization != null)
+                    _DetailRow('Chuyên ngành', request.toSpecialization!),
+                  if (request.toSubSpecialization != null)
+                    _DetailRow('Chuyên ngành hẹp', request.toSubSpecialization!),
+                  if (request.reason != null)
+                    _DetailRow('Lý do', request.reason!),
+                  if (request.note != null && request.note!.isNotEmpty)
+                    _DetailRow('Ghi chú', request.note!),
+                  if (request.dueDate != null)
+                    _DetailRow('Hạn nộp', request.dueDate!),
+                  _DetailRow('Ngày tạo', request.createdAt.split('T').first),
+                  if (request.approverName != null)
+                    _DetailRow('Người xét duyệt', request.approverName!),
+                  if (request.approvedAt != null)
+                    _DetailRow('Ngày xét duyệt', request.approvedAt!.split('T').first),
+                  if (request.approverNote != null && request.approverNote!.isNotEmpty)
+                    _DetailRow('Ghi chú người duyệt', request.approverNote!),
+                  if (request.fileUrl != null && request.fileUrl!.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 6),
+                      child: Row(
+                        children: [
+                          const Icon(Icons.attach_file_rounded, size: 16, color: AppColors.primaryOrange),
+                          const SizedBox(width: 8),
+                          const Text('File đính kèm: ', style: TextStyle(fontWeight: FontWeight.w600)),
+                          const Expanded(
+                            child: Text('Có file đính kèm',
+                                style: TextStyle(color: AppColors.primaryOrange)),
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            // Cancel button if PENDING
+            if (request.status == 'PENDING') ...[
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  icon: const Icon(Icons.cancel_outlined, color: Colors.red),
+                  label: const Text('Thu hồi yêu cầu', style: TextStyle(color: Colors.red)),
+                  style: OutlinedButton.styleFrom(
+                    side: const BorderSide(color: Colors.red),
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  ),
+                  onPressed: () {
+                    Get.back();
+                    Get.dialog(
+                      AlertDialog(
+                        title: const Text('Xác nhận thu hồi'),
+                        content: const Text('Bạn có chắc muốn thu hồi yêu cầu này?'),
+                        actions: [
+                          TextButton(onPressed: () => Get.back(), child: const Text('Hủy')),
+                          TextButton(
+                            onPressed: () {
+                              Get.back();
+                              controller.cancelRequest(request.id);
+                            },
+                            child: const Text('Thu hồi', style: TextStyle(color: Colors.red)),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  final String label;
+  final String value;
+  const _DetailRow(this.label, this.value);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 150,
+            child: Text(label,
+                style: TextStyle(fontSize: 13, color: Colors.grey[600], fontWeight: FontWeight.w500)),
+          ),
+          Expanded(
+            child: Text(value,
+                style: const TextStyle(fontSize: 13, color: Color(0xFF2D3436), fontWeight: FontWeight.w600)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilterChip extends StatelessWidget {
+  final String label;
+  final Color? color;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _FilterChip({
+    required this.label,
+    this.color,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          color: isSelected ? (color ?? AppColors.primaryOrange) : Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: isSelected ? (color ?? AppColors.primaryOrange) : Colors.grey[300]!,
+            width: 1.5,
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: isSelected ? Colors.white : Colors.grey[700],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/academic_request/widgets/academic_request_status_badge.dart
+++ b/mobile/lib/features/academic_request/widgets/academic_request_status_badge.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+/// Status badge widget for academic requests (Student)
+class AcademicRequestStatusBadge extends StatelessWidget {
+  final String status;
+  final String label;
+
+  const AcademicRequestStatusBadge({
+    super.key,
+    required this.status,
+    required this.label,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final config = _getConfig();
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: config.bg,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(config.icon, size: 12, color: config.fg),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: TextStyle(
+              color: config.fg,
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  _BadgeConfig _getConfig() {
+    switch (status) {
+      case 'PENDING':
+        return _BadgeConfig(
+          bg: Colors.amber[100]!,
+          fg: Colors.amber[800]!,
+          icon: Icons.hourglass_top_rounded,
+        );
+      case 'APPROVED':
+        return _BadgeConfig(
+          bg: Colors.green[100]!,
+          fg: Colors.green[800]!,
+          icon: Icons.check_circle_outline_rounded,
+        );
+      case 'REJECTED':
+        return _BadgeConfig(
+          bg: Colors.red[100]!,
+          fg: Colors.red[800]!,
+          icon: Icons.cancel_outlined,
+        );
+      case 'CANCELLED':
+        return _BadgeConfig(
+          bg: Colors.grey[200]!,
+          fg: Colors.grey[700]!,
+          icon: Icons.remove_circle_outline_rounded,
+        );
+      default:
+        return _BadgeConfig(
+          bg: Colors.grey[200]!,
+          fg: Colors.grey[700]!,
+          icon: Icons.help_outline_rounded,
+        );
+    }
+  }
+}
+
+class _BadgeConfig {
+  final Color bg;
+  final Color fg;
+  final IconData icon;
+  _BadgeConfig({required this.bg, required this.fg, required this.icon});
+}

--- a/mobile/lib/features/auth/models/user_model.dart
+++ b/mobile/lib/features/auth/models/user_model.dart
@@ -9,13 +9,19 @@ class User {
   final bool isPasswordChanged;
   final String? phone;
   final DateTime? dob;
-  
-  // Profile Info
+
+  // Profile Info (display names)
   final String? major;
   final String? specialization;
+  final String? subSpecialization;
   final String? department;
   final String? expertise;
   final String? faceDataStatus; // REGISTERED, NOT_REGISTERED, etc.
+
+  // Profile IDs (needed for dependent dropdowns)
+  final int? majorId;
+  final int? specializationId;
+  final int? subSpecializationId;
 
   User({
     required this.id,
@@ -29,9 +35,13 @@ class User {
     this.dob,
     this.major,
     this.specialization,
+    this.subSpecialization,
     this.department,
     this.expertise,
     this.faceDataStatus,
+    this.majorId,
+    this.specializationId,
+    this.subSpecializationId,
   });
 
   factory User.fromJson(Map<String, dynamic> json) {
@@ -47,9 +57,13 @@ class User {
       dob: json['dob'] != null ? DateTime.tryParse(json['dob'].toString()) : null,
       major: json['major'],
       specialization: json['specialization'],
+      subSpecialization: json['subSpecialization'],
       department: json['department'],
       expertise: json['expertise'],
       faceDataStatus: json['faceDataStatus'],
+      majorId: json['majorId'] as int?,
+      specializationId: json['specializationId'] as int?,
+      subSpecializationId: json['subSpecializationId'] as int?,
     );
   }
 
@@ -61,15 +75,19 @@ class User {
       'email': email,
       'role': role,
       'avatar': avatarUrl,
-      'avatarUrl': avatarUrl, 
+      'avatarUrl': avatarUrl,
       'isPasswordChanged': isPasswordChanged,
       'phone': phone,
       'dob': dob?.toIso8601String(),
       'major': major,
       'specialization': specialization,
+      'subSpecialization': subSpecialization,
       'department': department,
       'expertise': expertise,
       'faceDataStatus': faceDataStatus,
+      'majorId': majorId,
+      'specializationId': specializationId,
+      'subSpecializationId': subSpecializationId,
     };
   }
 

--- a/mobile/lib/features/home/views/home_screen.dart
+++ b/mobile/lib/features/home/views/home_screen.dart
@@ -388,7 +388,27 @@ class HomeScreen extends StatelessWidget {
                               onTap: () {},
                             ),
 
-                            // "Gửi đơn yêu cầu" card - only for lecturers
+                            // "Gửi đơn yêu cầu" card - for Students
+                            Obx(() {
+                              final user = authController.currentUser.value;
+                              if (user?.role != 'LECTURER') {
+                                return Column(
+                                  children: [
+                                    const SizedBox(height: 16),
+                                    _buildBigCard(
+                                      icon: Icons.article_outlined,
+                                      title: 'Gửi đơn yêu cầu',
+                                      onTap: () => Get.toNamed(
+                                        AppRoutes.studentAcademicRequests,
+                                      ),
+                                    ),
+                                  ],
+                                );
+                              }
+                              return const SizedBox.shrink();
+                            }),
+
+                            // "Gửi đơn yêu cầu" card - for Lecturers
                             Obx(() {
                               final user = authController.currentUser.value;
                               if (user?.role == 'LECTURER') {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -17,6 +17,9 @@ import 'features/schedule_request/views/schedule_request_list_screen.dart';
 import 'features/schedule_request/views/schedule_request_detail_screen.dart';
 import 'features/schedule_request/views/create_request_screen.dart';
 import 'features/schedule_request/bindings/schedule_request_bindings.dart';
+import 'features/academic_request/views/academic_request_list_screen.dart';
+import 'features/academic_request/views/academic_request_create_screen.dart';
+import 'features/academic_request/bindings/academic_request_bindings.dart';
 
 import 'features/chat/controllers/chat_controller.dart';
 import 'features/schedule/controllers/schedule_controller.dart';
@@ -105,6 +108,17 @@ class MyApp extends StatelessWidget {
           name: AppRoutes.lecturerRequestDetail,
           page: () => const ScheduleRequestDetailScreen(),
           binding: ScheduleRequestBinding(),
+        ),
+        // Student Academic Request Routes
+        GetPage(
+          name: AppRoutes.studentAcademicRequests,
+          page: () => const AcademicRequestListScreen(),
+          binding: AcademicRequestBinding(),
+        ),
+        GetPage(
+          name: AppRoutes.studentAcademicRequestCreate,
+          page: () => const AcademicRequestCreateScreen(),
+          binding: AcademicRequestBinding(),
         ),
       ],
     );

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -577,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: "direct main"
     description:
@@ -974,10 +974,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
- Implemented AcademicRequestListScreen to display a list of academic requests with filtering options.
- Added loading and empty state handling for the request list.
- Created a floating action button for creating new requests.
- Developed a detailed bottom sheet to show request details and actions.
- Introduced AcademicRequestStatusBadge widget to visually represent the status of requests.